### PR TITLE
Move clobber block to android platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Usage
 ### API
 
 ```javascript
-var permissions = window.plugins.permissions;
+var permissions = cordova.plugins.permissions;
 permissions.hasPermission(permission, successCallback, errorCallback);
 permissions.requestPermission(permission, successCallback, errorCallback);
 ```
@@ -48,7 +48,7 @@ Example
 --------
 
 ```javascript
-var permissions = window.plugins.permissions;
+var permissions = cordova.plugins.permissions;
 permissions.hasPermission(checkPermissionCallback, null, permissions.CAMERA);
 
 function checkPermissionCallback(status) {

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,12 +14,11 @@
     <engine name="cordova" version=">=5.0.0"/>
   </engines>
 
-  <js-module src="www/permissions.js" name="Permissions">
-    <clobbers target="window.plugins.permissions" />
-  </js-module>
-
   <!-- android -->
   <platform name="android">
+    <js-module src="www/permissions.js" name="Permissions">
+      <clobbers target="cordova.plugins.permissions" />
+    </js-module>
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="Permissions">

--- a/www/permissions.js
+++ b/www/permissions.js
@@ -157,7 +157,7 @@ function Permissions() {
 }
 
 function deprecated(name) {
-  console.warn("Calling window.plugins.permissions." + name + " with the successCallback as first argument is deprecated");
+  console.warn("Calling cordova.plugins.permissions." + name + " with the successCallback as first argument is deprecated");
   console.warn("The new signature is '" + name + "(permission, successCallback, errorCallback)'");
 }
 
@@ -181,13 +181,4 @@ Permissions.prototype = {
         cordova.exec(successCallback, errorCallback, permissionsName, 'requestPermission', [permission]);
     }
 };
-Permissions.install = function() {
-    if (!window.plugins) {
-        window.plugins = {};
-    }
-
-    window.plugins.permissions = new Permissions();
-    return window.plugins.permissions;
-};
-
-cordova.addConstructor(Permissions.install);
+module.exports = new Permissions();


### PR DESCRIPTION
before the block was global, so the plugin was instantiated on all platforms.
Now it will only be instantiated on Android.

This also changes how the plugin exposes itself to Cordova in a more standard way using `module.exports`.

Also moved the plugin from ` window.plugins`  to the more
canonical `cordova.plugins` namespace.